### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/src/org/labkey/fcsexpress/FCSExpressAssayProvider.java
+++ b/src/org/labkey/fcsexpress/FCSExpressAssayProvider.java
@@ -112,6 +112,7 @@ public class FCSExpressAssayProvider extends AbstractTsvAssayProvider
     }
 
     // XXX: duplicated from TsvAssayProvider
+    @Override
     public List<Pair<Domain, Map<DomainProperty, Object>>> createDefaultDomains(Container c, User user)
     {
         List<Pair<Domain, Map<DomainProperty, Object>>> result = super.createDefaultDomains(c, user);

--- a/src/org/labkey/fcsexpress/FCSExpressController.java
+++ b/src/org/labkey/fcsexpress/FCSExpressController.java
@@ -79,9 +79,8 @@ public class FCSExpressController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199